### PR TITLE
Add coverage threshold support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export default (options = {}) => {
 
     jest.runCLI(options, [options.rootDir]).then(({ results }) => {
       var hasCoverage = _ref.globalConfig.collectCoverage;
-      var hasThreshold = _ref.globalConfig .coverageThreshold || false;
+      var hasThreshold = _ref.globalConfig.coverageThreshold || false;
 
       if (results.numFailedTests || results.numFailedTestSuites) {
         cb(new _gulpUtil2.default.PluginError('gulp-jest', { message: 'Tests Failed' }));

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,13 @@ export default (options = {}) => {
     }, options);
 
     jest.runCLI(options, [options.rootDir]).then(({ results }) => {
-      if(results.numFailedTests || results.numFailedTestSuites) {
-        cb(new gutil.PluginError('gulp-jest', { message: 'Tests Failed' }));
+      var hasCoverage = _ref.globalConfig.collectCoverage;
+      var hasThreshold = _ref.globalConfig .coverageThreshold || false;
+
+      if (results.numFailedTests || results.numFailedTestSuites) {
+        cb(new _gulpUtil2.default.PluginError('gulp-jest', { message: 'Tests Failed' }));
+      } else if(hasCoverage && hasThreshold && !results.success) { 
+        cb(new _gulpUtil2.default.PluginError('gulp-jest', { message: 'Coverage threshold failed'}))
       } else {
         cb();
       }

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default (options = {}) => {
       if (results.numFailedTests || results.numFailedTestSuites) {
         cb(new _gulpUtil2.default.PluginError('gulp-jest', { message: 'Tests Failed' }));
       } else if(hasCoverage && hasThreshold && !results.success) { 
-        cb(new _gulpUtil2.default.PluginError('gulp-jest', { message: 'Coverage threshold failed'}))
+        cb(new _gulpUtil2.default.PluginError('gulp-jest', { message: 'Coverage threshold failed'}));
       } else {
         cb();
       }


### PR DESCRIPTION
I require the threshold support for my own project, so I've implemented it here. Tested with Node 7, previous code suggested on comments would trigger when coverage is set but no thresholds were set. This code triggers only when thresholds are set and throws an additional error delineated from error shown before. 